### PR TITLE
add check for that sq project exists

### DIFF
--- a/workflow-templates/starter-sonarqube-dotnet.yaml
+++ b/workflow-templates/starter-sonarqube-dotnet.yaml
@@ -32,6 +32,19 @@ jobs:
     runs-on: [self-hosted, linux, sonarqube]
     container: mcr.microsoft.com/dotnet/sdk:6.0
     steps:
+
+      # This can be removed once it's successful. It's only here to make sure that the SonarQube project has time to be created
+      - name: Check that the SonarQube project exists
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_URL }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          status_code=$(curl -u ${SONAR_TOKEN}: -s -o /dev/null -w "%{http_code}" "${SONAR_HOST_URL}api/components/show?component=${REPO_NAME}")
+          if [ "${status_code}" -eq 404 ] ; then
+            exit 1
+          fi
+
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:

--- a/workflow-templates/starter-sonarqube-golang.yaml
+++ b/workflow-templates/starter-sonarqube-golang.yaml
@@ -23,6 +23,19 @@ jobs:
     runs-on: [self-hosted, linux, sonarqube]
     container: golang:1.20
     steps:
+    
+      # This can be removed once it's successful. It's only here to make sure that the SonarQube project has time to be created
+      - name: Check that the SonarQube project exists
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_URL }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          status_code=$(curl -u ${SONAR_TOKEN}: -s -o /dev/null -w "%{http_code}" "${SONAR_HOST_URL}api/components/show?component=${REPO_NAME}")
+          if [ "${status_code}" -eq 404 ] ; then
+            exit 1
+          fi
+
       # Add ssh-key with read-access to all SnowSoftwareGlobal repositories
       - uses: webfactory/ssh-agent@v0.7.0
         with:


### PR DESCRIPTION
Oneliner fetches the http status code from the API. If the project does not exist, you get a 404. If it does exist, you get a 403 because the `SONAR_TOKEN` doesn't have enough access to show the endpoint. 

For once SonarQube being weird works in our favor 😄 