### PR TITLE
cleanup sonarqube workaround

### DIFF
--- a/workflow-templates/starter-sonarqube-dotnet.yaml
+++ b/workflow-templates/starter-sonarqube-dotnet.yaml
@@ -31,19 +31,6 @@ jobs:
     runs-on: [self-hosted, unix, sonarqube]
     container: mcr.microsoft.com/dotnet/sdk:6.0
     steps:
-
-      # This can be removed once it's successful. It's only here to make sure that the SonarQube project has time to be created
-      - name: Check that the SonarQube project exists
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_URL }}
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: |
-          status_code=$(curl -u ${SONAR_TOKEN}: -s -o /dev/null -w "%{http_code}" "${SONAR_HOST_URL}api/components/show?component=${REPO_NAME}")
-          if [ "${status_code}" -eq 404 ] ; then
-            exit 1
-          fi
-
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:

--- a/workflow-templates/starter-sonarqube-golang.yaml
+++ b/workflow-templates/starter-sonarqube-golang.yaml
@@ -22,19 +22,6 @@ jobs:
     runs-on: [self-hosted, unix, sonarqube]
     container: golang:1.20
     steps:
-    
-      # This can be removed once it's successful. It's only here to make sure that the SonarQube project has time to be created
-      - name: Check that the SonarQube project exists
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_URL }}
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: |
-          status_code=$(curl -u ${SONAR_TOKEN}: -s -o /dev/null -w "%{http_code}" "${SONAR_HOST_URL}api/components/show?component=${REPO_NAME}")
-          if [ "${status_code}" -eq 404 ] ; then
-            exit 1
-          fi
-
       # Add ssh-key with read-access to all SnowSoftwareGlobal repositories
       - uses: webfactory/ssh-agent@v0.7.0
         with:


### PR DESCRIPTION
This small script was used as a workaround for people running SonarQube workflows before the resources in there was applied by repo-as-code. After [this PR](https://github.com/SnowSoftwareGlobal/devops-repo-as-code/pull/212) we are applying the sonarqube side instantly on import/creating of the repository, which means this is no longer required. 